### PR TITLE
PRO-11140: ProvarDX : Unable to download metadata for any user if the

### DIFF
--- a/com.provar.plugins.provardx/src/utilities/ProvarDXUtility.ts
+++ b/com.provar.plugins.provardx/src/utilities/ProvarDXUtility.ts
@@ -98,7 +98,7 @@ export default class ProvarDXUtility {
                 jsonDxUser = JSON.parse(dxUserInfo.toString());
             }
             jsonDxUser.result.connection = overrides[i]['connection'];
-            jsonDxUser.result.password = jsonDxUser.result.password.replace('&', '"&"'); //replacing '&' with its ASCII value, '&' caused arguments to truncate when passed to java args.
+            jsonDxUser.result.password = this.handleSpecialCharacters(jsonDxUser.result.password);
             dxUsers.push(jsonDxUser);
         }
         if (dxUsers.length === 0) {
@@ -132,5 +132,14 @@ export default class ProvarDXUtility {
                 cli.action.stop(isSucessful ? 'successful' : 'failed');
             }
         }
+    }
+
+    private handleSpecialCharacters(password: string): string {
+        if (password) {
+             password = password.split('&').join('"&"');
+             password = password.split('|').join('"|"');
+             password = password.split('^').join('"^"');
+        }
+        return password;
     }
 }


### PR DESCRIPTION
password contains "|"


|, ^ was not handled, also handled & in a way that it can appear many
times earlier it was handled so that it can appear only once in password.

So a password "&jsjs&" was causing a login fault earlier.