### PR TITLE
PRO-16810: ProvarDX Incorrect Help messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2020-08-04
+
+### Changed
+
+-   Updated help messages for runtests, validate commands displayed on running `sfdx provar --help`
+-   Updated company name in LICENSE.md
+
 ## [0.2.1] - 2020-07-08
 
 ### Fixed

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2020, ProvarTesting
+Copyright (c) 2020, Make Positive Provar Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ EXAMPLE
 
 ## `sfdx provar:metadatacache`
 
-Command to pre-download any required metadata for a specified user or provar connections.
+Command to pre-download any required metadata for a specified user or provar connection
 
 ```
 USAGE
@@ -94,7 +94,7 @@ EXAMPLE
 
 ## `sfdx provar:runtests`
 
-Runs the specified list of Provar test cases against the currently configured SFDX defaultuserrname
+Runs a specified list of Provar test cases against a specified DevHub user alias or username
 
 ```
 USAGE
@@ -136,7 +136,7 @@ EXAMPLE
 
 ## `sfdx provar:validate`
 
-Validate the provardx property file agains standard JSON Schema
+Verify a property file to confirm it is a well formed provardx property file
 
 ```
 USAGE

--- a/messages/metadatacache.json
+++ b/messages/metadatacache.json
@@ -1,5 +1,5 @@
 {
-    "commandDescription": "Command to pre-download any required metadata for a specified user or provar connections.",
+    "commandDescription": "Command to pre-download any required metadata for a specified user or provar connection",
     "metadataLevelFlagDescription": "Permitted values reload (get all metadata - default) | refresh (only download changes).",
     "cachePathFlagDescription": "Relative or full file path for where the metadata cache will be stored.",
     "propertyFileFlagDescription": "Specify custom property file.",

--- a/messages/runtests.json
+++ b/messages/runtests.json
@@ -1,5 +1,5 @@
 {
-    "commandDescription": "Runs the specified list of Provar test cases against the currently configured SFDX defaultuserrname",
+    "commandDescription": "Runs a specified list of Provar test cases against a specified DevHub user alias or username",
     "propertyFileFlagDescription": "provardx-properties.json file. If filepath specified the filename will be assumed or it can be specified (.e.g myprops.json). File must be in JSON format and conform to the provardx-properties JSON schema.",
     "fileSpecFlagDescription": "Specify comma-delimited, ordered paths of test cases to be executed. If not provided all tests in the PROJECTPATH will be executed.",
     "connectionOverridefile": "Connection file in the format provardx-connection-schema.json providing a mapping between the Provar project Connection names and the target users to be used.",

--- a/messages/validate.json
+++ b/messages/validate.json
@@ -1,5 +1,5 @@
 {
-    "commandDescription": "Validate the provardx property file agains standard JSON Schema",
+    "commandDescription": "Verify a property file to confirm it is a well formed provardx property file",
     "propertyFileFlagDescription": "Specify custom property file.",
     "showErrorsFlagDescription": "Allow to show validation errors. Default is false.",
     "loglevelFlagDescription": "Allow to provide loglevels."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@provartesting/provardx",
     "description": "A plugin for the Salesforce CLI to run provar testcases",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "author": "Provar",
     "bugs": "https://github.com/ProvarTesting/provardx/issues",
     "dependencies": {
@@ -51,8 +51,20 @@
         "commands": "./lib/commands",
         "bin": "sfdx",
         "topics": {
-            "hello": {
-                "description": "Commands to say hello."
+            "provar": {
+                "description": "Developer tools for executing Provar tests from a command line and using Salesforce DevHub aliases"
+            },
+            "provar:compile": {
+                "description": "Pre-compiles any /src PageObject or PageControl Java source files into object code to use in runtests"
+            },
+            "provar:metadacache": {
+                "description": "Command to pre-download any required metadata for a specified user or provar connection"
+            },
+            "provar:runtests": {
+                "description": "Runs a specified list of Provar test cases against a specified DevHub user alias or username"
+            },
+            "provar:validate": {
+                "description": "Verify a property file to confirm it is a well formed provardx property file"
             }
         },
         "devPlugins": [

--- a/src/commands/provar/runtests.ts
+++ b/src/commands/provar/runtests.ts
@@ -13,7 +13,7 @@ import { cli } from 'cli-ux';
 import ProvarDXUtility from '../../utilities/ProvarDXUtility';
 
 /**
- * Runs the specified list of Provar test cases against the currently configured SFDX defaultuserrname unless overridden
+ * Runs a specified list of Provar test cases against a specified DevHub user alias or username unless overridden
  * in the command below or by a provardx-properties.json file
  * @author Himanshu Sharma
  *


### PR DESCRIPTION
-   Updated help messages for runtests, validate commands displayed on running `sfdx provar --help`
-   Updated company name in LICENSE.md