### PR TITLE
PRO-16923: ProvarDX runtests fails to handle special characters in Scratch Org Passwords properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 node_modules
 /.circleci
 /.sfdx
-/.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Remote",
+            "address": "127.0.0.1",
+            "port": 9229
+        },
+        {
+            "name": "Unit Tests",
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "program": "${workspaceRoot}/node_modules/.bin/_mocha",
+            "args": [
+                "--require",
+                "test/helpers/init.js",
+                "--require",
+                "ts-node/register",
+                "--require",
+                "source-map-support/register",
+                "--recursive",
+                "--reporter",
+                "spec",
+                "test/**/*.test.ts"
+            ],
+            "cwd": "${workspaceRoot}"
+        }
+    ]
+}

--- a/.vscode/provardx-copyright.code-snippets
+++ b/.vscode/provardx-copyright.code-snippets
@@ -1,0 +1,15 @@
+{
+	"Insert Copyright Header": {
+		"prefix": "copyright",
+		"body": [
+		  "/*",
+		  " * Copyright (c) 2020 Make Positive Provar Ltd",
+		  " * All rights reserved.",
+		  " * Licensed under the BSD 3-Clause license.",
+		  " * For full license text, see LICENSE.md file in the repo root or https://opensource.org/licenses/BSD-3-Clause",
+		  " */",
+		  "$0"
+		],
+		"description": "Insert the Provar copyright header"
+	  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3] - 2020-08-24
+## [0.2.3] - 2020-08-25
 
 ### Fixed
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   ProvarDX trademark changes
+-   Updated help messages for runtests
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2020-08-19
+
+### Fixed
+
+-   ProvarDX runtests, metadatacache command fails in case we are having special characters in Scratch Org password
+
+### Changed
+
+-   ProvarDX trademark changes
+
+### Added
+
+-   Added .vscode folder containing
+    -   `launch.json`: debug configuration for vscode
+    -   `provardx-copyright.code-snippets`: used to add copyright tag on source files
+
 ## [0.2.2] - 2020-08-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3] - 2020-08-19
+## [0.2.3] - 2020-08-24
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ OPTIONS
                                                        must be in JSON format and conform to the provardx-properties
                                                        JSON schema.
 
-  -s, --secrets=secrets                                Specify path to secrets file
+  -s, --secrets=secrets                                Specify secrets encryption password. Alternatively, it can be specified
+                                                       in provardx-properties.json file as well.
 
   --json                                               format output as json
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# provartesting/provardx
+# ProvarDX™
 
-ProvarDX is a Salesforce CLI Plugin for existing Provar customer to allow them to execute Provar Test Cases from the command line, leveraging the Salesforce CLI and SalesforceDX applications. This provides an alternative mechanism for running test cases than running under ANT.
+ProvarDX™ is a Salesforce CLI Plugin for existing Provar customer to allow them to execute Provar Test Cases from the command line, leveraging the Salesforce CLI and SalesforceDX applications. This provides an alternative mechanism for running test cases than running under ANT.
 You must be a Provar customer with a valid paid license to write and maintain your test cases.
 
 [![Version](https://img.shields.io/npm/v/@provartesting/provardx.svg)](https://npmjs.org/package/@provartesting/provardx)

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ OPTIONS
                                                        must be in JSON format and conform to the provardx-properties
                                                        JSON schema.
 
-  -s, --secrets=secrets                                Specify secrets encryption password. Alternatively, it can be specified
-                                                       in provardx-properties.json file as well.
+  -s, --secrets=secrets                                Specify a secrets encryption key for accessing the chosen project/environment.
 
   --json                                               format output as json
 

--- a/messages/runtests.json
+++ b/messages/runtests.json
@@ -5,6 +5,6 @@
     "connectionOverridefile": "Connection file in the format provardx-connection-schema.json providing a mapping between the Provar project Connection names and the target users to be used.",
     "cachePathFlagDescription": "Specify relative or full file path for where a metadata cache has already been downloaded using either a VCS extract or metadata ProvarDX command.",
     "metadataLevelFlagDescription": "Specify permitted values reload (get all metadata - default) | refresh (only download changes). This overrides any settings made in the propertyfile.",
-    "secretsFlagDescription": "Specify secrets encryption password. Alternatively, it can be specified in provardx-properties.json file as well.",
+    "secretsFlagDescription": "Specify a secrets encryption key for accessing the chosen project/environment.",
     "loglevelFlagDescription": "Specify the level of feedback provided during the compilation (see above) and execution."
 }

--- a/messages/runtests.json
+++ b/messages/runtests.json
@@ -5,6 +5,6 @@
     "connectionOverridefile": "Connection file in the format provardx-connection-schema.json providing a mapping between the Provar project Connection names and the target users to be used.",
     "cachePathFlagDescription": "Specify relative or full file path for where a metadata cache has already been downloaded using either a VCS extract or metadata ProvarDX command.",
     "metadataLevelFlagDescription": "Specify permitted values reload (get all metadata - default) | refresh (only download changes). This overrides any settings made in the propertyfile.",
-    "secretsFlagDescription": "Specify path to secrets file",
+    "secretsFlagDescription": "Specify secrets encryption password. Alternatively, it can be specified in provardx-properties.json file as well.",
     "loglevelFlagDescription": "Specify the level of feedback provided during the compilation (see above) and execution."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@provartesting/provardx",
     "description": "A plugin for the Salesforce CLI to run provar testcases",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "author": "Provar",
     "bugs": "https://github.com/ProvarTesting/provardx/issues",
     "dependencies": {

--- a/src/utilities/ProvarDXUtility.ts
+++ b/src/utilities/ProvarDXUtility.ts
@@ -169,9 +169,7 @@ export default class ProvarDXUtility {
 
     private handleSpecialCharacters(password: string): string {
         if (password) {
-            password = password.split('&').join('"&"');
-            password = password.split('|').join('"|"');
-            password = password.split('^').join('"^"');
+            password = password.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
         }
         return password;
     }

--- a/src/utilities/ProvarDXUtility.ts
+++ b/src/utilities/ProvarDXUtility.ts
@@ -169,7 +169,7 @@ export default class ProvarDXUtility {
 
     private handleSpecialCharacters(password: string): string {
         if (password) {
-            password = password.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+            password = encodeURIComponent(password);
         }
         return password;
     }


### PR DESCRIPTION
**Issue:** Scratch org password had special characters. Earlier we had only escaped **&, |, ^** special characters.

**Fix:** Encoded password value.

Also contains changes for:

1. ProvarDX trademark changes.

1. Added .vscode folder in git containing debug configuration and copyright snippet.