### PR TITLE
PRO-16890 : Enforce required flags for provar:metadatacache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.4] - 2020-08-25
+
+### Fixed
+
+-   Enforced the required flags for ProvarDX metadatacache command
+-   Fixed the working of flags for ProvarDX metadatacache command in tandem
+
+## [0.2.3] - 2020-08-25
+
+### Fixed
+
+-   ProvarDX runtests, metadatacache command fails in case we are having special characters in Scratch Org password
+
+### Changed
+
+-   ProvarDX trademark changes
+-   Updated help messages for runtests
+
+### Added
+
+-   Added .vscode folder containing
+    -   `launch.json`: debug configuration for vscode
+    -   `provardx-copyright.code-snippets`: used to add copyright tag on source files
+
 ## [0.2.2] - 2020-08-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@provartesting/provardx",
     "description": "A plugin for the Salesforce CLI to run provar testcases",
-    "version": "0.2.2",
+    "version": "0.2.4",
     "author": "Provar",
     "bugs": "https://github.com/ProvarTesting/provardx/issues",
     "dependencies": {

--- a/src/commands/provar/metadatacache.ts
+++ b/src/commands/provar/metadatacache.ts
@@ -90,9 +90,7 @@ export default class MetadataCache extends SfdxCommand {
             return {};
         }
 
-        if (
-            metadataLevel !== "Reload" && metadataLevel !== "Refresh" && metadataLevel !== "Reuse"
-        ) {
+        (!["Reload", "Refresh", "Reuse"].includes(metadataLevel)) {
             this.ux.error(
                 "ERROR running provar:metadatacache : Please specify a valid metadata level(-m flag). Valid levels are : 'Reuse', 'Refresh' and 'Reload'"
             );
@@ -142,7 +140,7 @@ export default class MetadataCache extends SfdxCommand {
             return {};
         }
 
-        const userInfoString = connections && userInfo == null ? "NA" : provarDxUtils.prepareRawProperties(
+        const userInfoString = connections && userInfo === null ? "NA" : provarDxUtils.prepareRawProperties(
             JSON.stringify({ dxUsers: userInfo })
         );
         const jarPath = properties.provarHome + '/provardx/provardx.jar';

--- a/src/commands/provar/metadatacache.ts
+++ b/src/commands/provar/metadatacache.ts
@@ -90,7 +90,7 @@ export default class MetadataCache extends SfdxCommand {
             return {};
         }
 
-        (!["Reload", "Refresh", "Reuse"].includes(metadataLevel)) {
+        if (!["Reload", "Refresh", "Reuse"].includes(metadataLevel)) {
             this.ux.error(
                 "ERROR running provar:metadatacache : Please specify a valid metadata level(-m flag). Valid levels are : 'Reuse', 'Refresh' and 'Reload'"
             );

--- a/src/commands/provar/metadatacache.ts
+++ b/src/commands/provar/metadatacache.ts
@@ -133,7 +133,7 @@ export default class MetadataCache extends SfdxCommand {
         const userInfo = await provarDxUtils.getDxUsersInfo(
             properties.connectionOverride
         );
-        if (userInfo == null && !connections) {
+        if (userInfo === null && !connections) {
             this.ux.error(
                 '[ERROR] No valid user org found to download metadata. Terminating command.'
             );
@@ -191,7 +191,7 @@ export default class MetadataCache extends SfdxCommand {
             const overrides = properties.connectionName.split(',');
             const connOver = [];
             for (const override of properties.connectionOverride) {
-                if (overrides.indexOf(override.connection) != -1) {
+                if (overrides.indexOf(override.connection) !== -1) {
                     connOver.push(override);
                 }
             }
@@ -201,10 +201,10 @@ export default class MetadataCache extends SfdxCommand {
         if (connectionOverride) {
             const overrides = connectionOverride.split(',');
             for (const override of overrides) {
-                const v = override.split(':');
-                const prop = properties.connectionOverride.find(f => f.connection === v[0]);
+                const overrideDetails = override.split(':');
+                const prop = properties.connectionOverride.find(f => f.connection === overrideDetails[0]);
                 if(prop){
-                    prop.username = v[1];
+                    prop.username = overrideDetails[1];
                 }
             }
         }


### PR DESCRIPTION
The command started executing even when required flags were not given. Changed that to give error in typescript itself. Also made changes to make sure that the flags work correctly in tandem.