### PR TITLE
PRO-17213: ProvarDX 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [0.2.4] - 2020-08-25
-
-### Fixed
-
--   Enforced the required flags for ProvarDX metadatacache command
--   Fixed the working of flags for ProvarDX metadatacache command in tandem
-
-## [0.2.3] - 2020-08-25
+## [0.3.0] - 2020-09-11
 
 ### Fixed
 
 -   ProvarDX runtests, metadatacache command fails in case we are having special characters in Scratch Org password
+-   Enforced the required flags for ProvarDX metadatacache command
+-   Fixed the working of flags for ProvarDX metadatacache command in tandem
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
     "name": "@provartesting/provardx",
     "description": "A plugin for the Salesforce CLI to run provar testcases",
-
-    "version": "0.2.4",
+    "version": "0.3.0",
     "author": "Provar",
     "bugs": "https://github.com/ProvarTesting/provardx/issues",
     "dependencies": {


### PR DESCRIPTION
Bumped version to 0.3.0

Since we have done minor improvements to ProvarDX package so bumped the version from 0.2.2 to 0.3.0:

- ProvarDX runtests, metadatacache command fails in case we are having special characters in Scratch Org password
-   Enforced the required flags for ProvarDX metadatacache command
-   Fixed the working of flags for ProvarDX metadatacache command in tandem