### PR TITLE
PRO-17489: Removed testOutputLevel enum from schema file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Support for Edge Chromium
--   Updated Enum for testOutputLevel and Removed from schema to ignore validation
+-   Updated Enum for testOutputLevel and removed from schema to ignore validation
 
 ## [0.3.0] - 2020-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Support for Edge Chromium
--   Updated Enum for testOutputLevel
+-   Updated Enum for testOutputLevel and Removed from schema to ignore validation
 
 ## [0.3.0] - 2020-09-11
 

--- a/src/utilities/DxPropertiesSchema.ts
+++ b/src/utilities/DxPropertiesSchema.ts
@@ -40,8 +40,7 @@ export const schema = {
         testOutputLevel: {
             description:
                 'Controls the amount of test output logged to the DX test log.',
-            type: 'string',
-            enum: ['EL', 'DD', 'DT']
+            type: 'string'
         },
         pluginOutputlevel: {
             description:


### PR DESCRIPTION
Removed testOutputLevel enum from DxPropertiesSchema.ts file to ignore the same for backward compatibility.