### PR TITLE
PRO-26089 : ProvarDX Metadatacache and runtests command is not working with latest SFDX for Scratch Org.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@provartesting/provardx",
     "description": "A plugin for the Salesforce CLI to run provar testcases",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "author": "Provar",
     "bugs": "https://github.com/ProvarTesting/provardx/issues",
     "dependencies": {

--- a/src/utilities/ProvarDXUtility.ts
+++ b/src/utilities/ProvarDXUtility.ts
@@ -98,7 +98,7 @@ export default class ProvarDXUtility {
             const message =
                 'Validating and retriving dx user info: ' + username;
             let dxUserInfo = await this.executeCommand(
-                'sfdx force:user:display --json -u ' + username,
+                'sfdx org:display:user --json --target-org ' + username,
                 message
             );
             let jsonDxUser = JSON.parse(dxUserInfo.toString());
@@ -117,7 +117,7 @@ export default class ProvarDXUtility {
                     'Generating password for user: ' + username
                 );
                 dxUserInfo = await this.executeCommand(
-                    'sfdx force:user:display --json -u ' + username,
+                    'sfdx org:display:user --json --target-org ' + username,
                     'Getting generated password for user: ' + username
                 );
                 jsonDxUser = JSON.parse(dxUserInfo.toString());


### PR DESCRIPTION
We were using some deprecated sfdx commands which were giving some warnings along with DxUserInfo API results and that warnings were further sent along with other commandArgs and data to DxCommandExecutor, causing change in number of arguments and their order and hence throwing no enum constant exception.