### PR TITLE
deprecate test plan detection prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@provartesting/provardx",
     "description": "A plugin for the Salesforce CLI to run provar testcases",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "author": "Provar",
     "bugs": "https://github.com/ProvarTesting/provardx/issues",
     "dependencies": {

--- a/src/commands/provar/runtests.ts
+++ b/src/commands/provar/runtests.ts
@@ -106,18 +106,6 @@ export default class RunTests extends SfdxCommand {
         );
 
         if (
-            provarDxUtils.getProperties().testPlan &&
-            provarDxUtils.getProperties().connectionOverride
-        ) {
-            const selection = await cli.prompt(
-                'Test plans detected, connection overrides will be ignored, do you wish to continue (Y/N)? '
-            );
-            if (selection.toLowerCase() === 'n') {
-                return {};
-            }
-        }
-
-        if (
             !isValid ||
             provarDxUtils.hasDuplicateConnectionOverride(
                 provarDxUtils.getProperties()


### PR DESCRIPTION
Test plan prompt is unnecessary as connection overrides work properly with Test Plans in ProvarDX. 
It also forces users to unintuitively prefix their `sfdx provar:runtests` command with a piped echo statement. Otherwise, all test plan executions with ProvarDX require manual intervention, which is not ideal. 
Test Plans are the default method of CI execution with Provar Manager now, so it makes sense to make this process seamless.
